### PR TITLE
Adding template_searchpath attribute to DAG object

### DIFF
--- a/airflow/bin/airflow
+++ b/airflow/bin/airflow
@@ -65,7 +65,8 @@ def run(args):
     iso = args.execution_date.isoformat()
     filename = "{directory}/{iso}".format(**locals())
     logging.basicConfig(
-        filename=filename, level=logging.INFO,
+        filename=filename, 
+        level=logging.INFO,
         format=settings.LOG_FORMAT)
 
     if not args.pickle:
@@ -76,8 +77,11 @@ def run(args):
         task = dag.get_task(task_id=args.task_id)
     else:
         session = settings.Session()
+        logging.info('Loading pickle id {args.pickle}'.format(**locals()))
         dag_pickle = session.query(
-            DagPickle).filter(DagPickle.id == args.pickle).all()[0]
+            DagPickle).filter(DagPickle.id == args.pickle).first()
+        if not dag_pickle:
+            raise Exception("Who hid the pickle!? [missing pickle]")
         dag = dag_pickle.get_object()
         task = dag.get_task(task_id=args.task_id)
 
@@ -93,9 +97,18 @@ def run(args):
             ignore_dependencies=args.ignore_dependencies)
         run_job.run()
     else:
+        # Pickling the DAG
+        session = settings.Session()
+        pickle = DagPickle(dag)
+        session.add(pickle)
+        session.commit()
+        pickle_id = pickle.id
+        print(
+            'Pickled dag {dag} '
+            'as pickle_id:{pickle_id}').format(**locals())
         executor = DEFAULT_EXECUTOR
         executor.start()
-        executor.queue_command(ti.key, ti.command())
+        executor.queue_command(ti.key, ti.command(pickle_id=pickle_id))
         executor.end()
 
 


### PR DESCRIPTION
This allows to define a template searchpath at the DAG level. It's a list of folders jinja should look through when referencing templates.
```
dag = DAG(dag_id='core_whatever', template_searchpath=['/srv/data/awesome_templates', '/srv/data/more_macros'])
```
