### PR TITLE
Task "adhoc" parameter

### DIFF
--- a/airflow/bin/airflow
+++ b/airflow/bin/airflow
@@ -49,7 +49,8 @@ def backfill(args):
     dag.run(
         start_date=args.start_date,
         end_date=args.end_date,
-        mark_success=args.mark_success)
+        mark_success=args.mark_success,
+        include_adhoc=args.include_adhoc)
 
 
 def run(args):
@@ -319,6 +320,9 @@ if __name__ == '__main__':
         "-e", "--end_date", help="Overide end_date YYYY-MM-DD")
     parser_backfill.add_argument(
         "-m", "--mark_success",
+        help=mark_success_help, action="store_true")
+    parser_backfill.add_argument(
+        "-a", "--include_adhoc",
         help=mark_success_help, action="store_true")
     parser_backfill.add_argument(
         "-i", "--ignore_dependencies",

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -781,6 +781,7 @@ class BaseOperator(Base):
             dag=None,
             params=None,
             default_args=None,
+            adhoc=True,
             *args,
             **kwargs):
 
@@ -800,6 +801,7 @@ class BaseOperator(Base):
         self.retries = retries
         self.retry_delay = retry_delay
         self.params = params or {}  # Available in templates!
+        self.adhoc = adhoc
 
         # Private attributes
         self._upstream_list = []
@@ -1274,10 +1276,16 @@ class DAG(Base):
         session.merge(self)
         session.commit()
 
-    def run(self, start_date=None, end_date=None, mark_success=False):
+    def run(
+            self, start_date=None, end_date=None, mark_success=False,
+            include_adhoc=False):
         from airflow import jobs
         job = jobs.BackfillJob(
-            self, start_date, end_date, mark_success)
+            self,
+            start_date=start_date,
+            end_date=end_date,
+            mark_success=mark_success,
+            include_adhoc=include_adhoc)
         job.run()
 
 


### PR DESCRIPTION
The master scheduler will disregard tasks set as adhoc=True. 

Backfill disregards by default, but can be set to include adhoc tasks (--include_adhoc)