### PR TITLE
[PrestoValueCheck] New operator for value checking

### DIFF
--- a/airflow/operators/__init__.py
+++ b/airflow/operators/__init__.py
@@ -3,6 +3,7 @@ from mysql_operator import MySqlOperator
 from hive_operator import HiveOperator
 from presto_check_operator import PrestoCheckOperator
 from presto_check_operator import PrestoIntervalCheckOperator
+from presto_check_operator import PrestoValueCheckOperator
 from sensors import SqlSensor
 from sensors import ExternalTaskSensor
 from sensors import HivePartitionSensor


### PR DESCRIPTION
PrestoValueCheck allows to define the value the SQL query should return
in order to pass the check. This can enable more readable SQL checks.
PrestoValueCheck can accomodate string values or numeric values with or
without a tolerance, which allows for close results.

@mistercrunch