### PR TITLE
Tree view base time fix

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -899,8 +899,11 @@ class Airflow(BaseView):
 
         num_runs = request.args.get('num_runs')
         num_runs = int(num_runs) if num_runs else 25
+        from_time = datetime.min.time()
+        if dag.start_date:
+            from_time = dag.start_date.time()
         from_date = (base_date-(num_runs * dag.schedule_interval)).date()
-        from_date = datetime.combine(from_date, datetime.min.time())
+        from_date = datetime.combine(from_date, from_time)
 
         dates = utils.date_range(
             from_date, base_date, dag.schedule_interval)


### PR DESCRIPTION
We are seeing the following behavior. We have a once-a-day DAG that runs at 8am UTC. The Tree View is not showing any history for the DAG. The cause is that the ```dates``` dictionary in the ```tree``` method does not take into account the time offset of the daily DAG.

The fix is to base the ```dates``` dictionary on the DAG start time.