### PR TITLE
[setup] selective features and imports for hooks and operators

### DIFF
--- a/airflow/hooks/__init__.py
+++ b/airflow/hooks/__init__.py
@@ -1,8 +1,30 @@
-from airflow.hooks.mysql_hook import MySqlHook
-from airflow.hooks.postgres_hook import PostgresHook
+import logging
+
+try:
+    from airflow.hooks.mysql_hook import MySqlHook
+except:
+    logging.INFO("Couldn't load MySQLHook")
+    pass
+
+try:
+    from airflow.hooks.postgres_hook import PostgresHook
+except:
+    logging.INFO("Couldn't import PostgreHook")
+    pass
+
 from airflow.hooks.hive_hooks import HiveCliHook
 from airflow.hooks.hive_hooks import HiveMetastoreHook
 from airflow.hooks.hive_hooks import HiveServer2Hook
 from airflow.hooks.presto_hook import PrestoHook
-from airflow.hooks.samba_hook import SambaHook
-from airflow.hooks.S3_hook import S3Hook
+
+try:
+    from airflow.hooks.samba_hook import SambaHook
+except:
+    logging.INFO("Couldn't import SambaHook")
+    pass
+
+try:
+    from airflow.hooks.S3_hook import S3Hook
+except:
+    logging.INFO("Couldn't import S3Hook")
+    pass

--- a/airflow/operators/__init__.py
+++ b/airflow/operators/__init__.py
@@ -1,7 +1,20 @@
+import logging
+
 from bash_operator import BashOperator
 from python_operator import PythonOperator
-from mysql_operator import MySqlOperator
-from postgres_operator import PostgresOperator
+
+try:
+    from mysql_operator import MySqlOperator
+except:
+    logging.INFO("Couldn't import MySqlOperator")
+    pass
+
+try:
+    from postgres_operator import PostgresOperator
+except:
+    logging.INFO("Couldn't import PostgresOperator")
+    pass
+
 from hive_operator import HiveOperator
 from presto_check_operator import PrestoCheckOperator
 from presto_check_operator import PrestoIntervalCheckOperator
@@ -10,10 +23,22 @@ from sensors import SqlSensor
 from sensors import ExternalTaskSensor
 from sensors import HivePartitionSensor
 from sensors import HdfsSensor
-from sensors import S3KeySensor
-from sensors import S3PrefixSensor
+
+try:
+    from sensors import S3KeySensor
+    from sensors import S3PrefixSensor
+except:
+    logging.INFO("Couldn't import S3KeySensor, S3PrefixSensor")
+    pass
+
 from sensors import TimeSensor
 from email_operator import EmailOperator
 from dummy_operator import DummyOperator
-from hive2samba_operator import Hive2SambaOperator
+
+try:
+    from hive2samba_operator import Hive2SambaOperator
+except:
+    logging.INFO("Couldn't import Hive2SambaOperator")
+    pass
+
 from subdag_operator import SubDagOperator

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,19 @@ from setuptools import setup, find_packages
 # Kept manually in sync with airflow.__version__
 version = '0.3.2.7'
 
+
+doc = ['sphinx>=1.2.3',
+        'sphinx-argparse>=0.1.13',
+        'sphinx-rtd-theme>=0.1.6',
+        'Sphinx-PyPI-upload>=0.2.1']
+postgres = ['psycopg2>=2.6']
+mysql = ['mysql-python>=1.2.5']
+samba = ['pysmbclient>=0.1.3']
+s3 = ['boto>=2.36.0']
+all_dbs = postgres + mysql
+devel = all_dbs + doc + samba + s3
+
+
 setup(
     name='airflow',
     description='Programmatically author, schedule and monitor data pipelines',
@@ -12,7 +25,6 @@ setup(
     zip_safe=False,
     scripts=['airflow/bin/airflow'],
     install_requires=[
-        'boto>=2.36.0',
         'celery>=3.1.17',
         'chartkick>=0.4.2',
         'dill>=0.2.2',
@@ -26,26 +38,29 @@ setup(
         'jinja2>=2.7.3',
         'librabbitmq>=1.6.1',
         'markdown>=2.5.2',
-        'mysql-python>=1.2.5',
         'pandas>=0.15.2',
-        'psycopg2>=2.6',
         'pygments>=2.0.1',
-        'pysmbclient>=0.1.3',
         'pyhive>=0.1.3',
         'pyhs2>=0.6.0',
         'python-dateutil>=2.3',
         'requests>=2.5.1',
         'setproctitle>=1.1.8',
         'snakebite>=2.4.13',
-        'sphinx>=1.2.3',
-        'sphinx-argparse>=0.1.13',
-        'sphinx-rtd-theme>=0.1.6',
-        'Sphinx-PyPI-upload>=0.2.1',
         'sqlalchemy>=0.9.8',
         'statsd>=3.0.1',
         'thrift>=0.9.2',
         'tornado>=4.0.2',
     ],
+    extras_require={
+        "postgres": postgres,
+        "mysql": mysql,
+        "all_dbs": all_dbs,
+        "samba": samba,
+        "s3": s3,
+        "doc": doc,
+        "devel": devel,
+        "all": devel
+        },
     author='Maxime Beauchemin',
     author_email='maximebeauchemin@gmail.com',
     url='https://github.com/mistercrunch/Airflow',


### PR DESCRIPTION
@mistercrunch 

I am not exactly sure how to install Airflow using the setup.py with the extras, but one can use `pip install -e .[key_in_extras_require]` for instance `pip install -e .[all]` for installing everything.

This was inspired by the setuptools docs and the ipython setup.py
