### PR TITLE
Found what was slowing down the master scheduler as it ran longer

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -61,8 +61,12 @@ class CeleryExecutor(BaseExecutor):
             if self.last_state[key] != async.state:
                 if async.state == celery_states.SUCCESS:
                     self.change_state(key, State.SUCCESS)
+                    del self.tasks[key]
+                    del self.last_state[key]
                 elif async.state == celery_states.FAILURE:
                     self.change_state(key, State.FAILED)
+                    del self.tasks[key]
+                    del self.last_state[key]
                 self.last_state[key] = async.state
 
     def end(self):


### PR DESCRIPTION
Since we've had higher workload the master scheduler has been slowing down almost every day until I'd get datadog alerts when runs would get more than 5 minutes apart. This should fix it.