### PR TITLE
add variables kv-store model

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1551,4 +1551,4 @@ class Variable(Base):
     val = Column(Text)
 
     def __repr__(self):
-        return '"{}" : {}'.format(self.key, self.key)
+        return '{} : {}'.format(self.key, self.val)

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1541,3 +1541,14 @@ class KnownEvent(Base):
 
     def __repr__(self):
         return self.label
+
+
+class Variable(Base):
+    __tablename__ = "variable"
+
+    id = Column(Integer, primary_key=True)
+    key = Column(String(512))
+    val = Column(Text)
+
+    def __repr__(self):
+        return '"{}" : {}'.format(self.key, self.key)

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -1185,6 +1185,27 @@ class Airflow(BaseView):
             height=height,
         )
 
+    @expose('/variables/<form>', methods=["GET", "POST"])
+    @login_required
+    def variables(self, form):
+        try:
+            if request.method == 'POST':
+                data = request.json
+                print data
+                if data:
+                    session = settings.Session()
+                    var = models.Variable(key=form, val=json.dumps(data))
+                    session.add(var)
+                    session.commit() 
+                return ""
+            else:
+                return self.render(
+                    'airflow/variables/{}.html'.format(form)
+                )
+        except:
+            return ("Error: form airflow/variables/{}.html "
+                    "not found.").format(form), 404
+
 
 admin.add_view(Airflow(name='DAGs'))
 
@@ -1596,3 +1617,10 @@ mv = KnowEventTypeView(
     Session, name="Known Event Types", category="Manage")
 admin.add_view(mv)
 '''
+
+class VariableView(LoginMixin, ModelView):
+    pass
+
+mv = VariableView(
+    models.Variable, Session, name="Variables", category="Browse")
+admin.add_view(mv)

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -1622,5 +1622,5 @@ class VariableView(LoginMixin, ModelView):
     pass
 
 mv = VariableView(
-    models.Variable, Session, name="Variables", category="Browse")
+    models.Variable, Session, name="Variables", category="Admin")
 admin.add_view(mv)

--- a/airflow/www/templates/airflow/variables/README.md
+++ b/airflow/www/templates/airflow/variables/README.md
@@ -1,0 +1,37 @@
+## Variable Editor
+----
+This folder contains forms used to edit values in the "Variable" key-value
+store.  This data can be edited under the "Browse" admin tab, but sometimes
+it is preferable to use a form that can perform checking and provide a nicer
+interface.
+
+### Adding a new form
+
+1. Create an html template in `templates/variables` folder
+2. Provide an interface for the user to provide input data
+3. Submit a post request that adds the data as json.  
+
+An example ajax POST request is provided below:
+```js
+$("#submit-btn").click(function() {
+  form_data = getData()
+  if (isValid(form_data)) {
+    $.ajax({
+      method: "POST",
+      url: "backfill",
+      data: JSON.stringify(form_data),
+      dataType: "json",
+      contentType: "application/json",
+      success: function(response_data) {
+        console.log("success.")
+      },
+      failure: function(response_data) {
+        console.log("post error.")            
+      }
+    })
+  }
+  else {
+    console.log("input error.")
+  }
+});
+```

--- a/airflow/www/templates/airflow/variables/README.md
+++ b/airflow/www/templates/airflow/variables/README.md
@@ -1,7 +1,7 @@
 ## Variable Editor
 ----
 This folder contains forms used to edit values in the "Variable" key-value
-store.  This data can be edited under the "Browse" admin tab, but sometimes
+store.  This data can be edited under the "Admin" admin tab, but sometimes
 it is preferable to use a form that can perform checking and provide a nicer
 interface.
 


### PR DESCRIPTION
@mistercrunch 

This PR adds a model called "Variable," which can be used to pass around small pieces of information within the app.  This is useful for defining parameters for adhoc tasks such as backfill jobs.  "Variable" is a key-value store, where the value is typically a JSON object.  Data can be entered via either the "Browse->Variables" Admin tab or through a POST request.  Forms dropped in the templates/variables folder help users create POST requests in a way that provides structure and verification for more complex data.