### PR TITLE
Query view crash

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -1235,7 +1235,8 @@ class QueryView(DataProfilingMixin, BaseView):
     def query(self):
         session = settings.Session()
         dbs = session.query(models.Connection).order_by(
-            models.Connection.conn_id)
+            models.Connection.conn_id).all()
+        session.expunge_all()
         db_choices = [(db.conn_id, db.conn_id) for db in dbs if db.get_hook()]
         conn_id_str = request.args.get('conn_id')
         csv = request.args.get('csv') == "true"


### PR DESCRIPTION
We are seeing the following stack trace:
```
2015-05-01 18:57:11,599 - werkzeug - INFO - 54.149.72.187 - - [01/May/2015 18:57:11] "GET /admin/queryview/ HTTP/1.1" 500 -
Traceback (most recent call last):
  File "./env/lib/python2.7/site-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "./env/lib/python2.7/site-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "./env/lib/python2.7/site-packages/flask/app.py", line 1403, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "./env/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "./env/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "./env/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "./env/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "./env/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "./env/lib/python2.7/site-packages/flask_admin/base.py", line 68, in inner
    return self._run_view(f, *args, **kwargs)
  File "./env/lib/python2.7/site-packages/flask_admin/base.py", line 354, in _run_view
    return fn(self, *args, **kwargs)
  File "./env/lib/python2.7/site-packages/airflow/www/utils.py", line 52, in view_func
    return f(*args, **kwargs)
  File "./env/lib/python2.7/site-packages/airflow/www/app.py", line 1248, in query
    db_choices = [(db.conn_id, db.conn_id) for db in dbs if db.get_hook()]
  File "./env/lib/python2.7/site-packages/sqlalchemy/orm/attributes.py", line 237, in __get__
    return self.impl.get(instance_state(instance), dict_)
  File "./env/lib/python2.7/site-packages/sqlalchemy/orm/attributes.py", line 573, in get
    value = state._load_expired(state, passive)
  File "./env/lib/python2.7/site-packages/sqlalchemy/orm/state.py", line 480, in _load_expired
    self.manager.deferred_scalar_loader(self, toload)
  File "./env/lib/python2.7/site-packages/sqlalchemy/orm/loading.py", line 608, in load_scalar_attributes
    (state_str(state)))
DetachedInstanceError: Instance <Connection at 0x7f8331cf0850> is not bound to a Session; attribute refresh operation cannot proceed
```