### PR TITLE
Prioritization and concurency limitation on executor queues

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,8 +16,9 @@ TODO
 
 #### Backend
 * Pickle all the THINGS!
-* Master auto dag refresh at time intervals
-* Prevent timezone chagne on import
+* Add priority_weight(Int) to BaseOperator, +@property subtree_priority
+* BaseExecutor parallelism limit
+* Distributed scheduler
 * Add decorator to timeout imports on master process [lib](https://github.com/pnpnpn/timeout-decorator)
 
 #### Wishlist

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -139,7 +139,7 @@ def run(args):
             ignore_dependencies=args.ignore_dependencies,
             pickle_id=pickle_id)
         print("Sending run command to executor:\n" + cmd)
-        executor.queue_command(ti.key, cmd)
+        executor.queue_task_instance(ti)
         executor.end()
 
 

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -6,6 +6,7 @@ import os
 defaults = {
     'core': {
         'unit_test_mode': False,
+        'parallelism': 32,
     },
     'webserver': {
         'base_url': 'http://localhost:8080',
@@ -30,6 +31,7 @@ dags_folder = {AIRFLOW_HOME}/dags
 base_log_folder = {AIRFLOW_HOME}/logs
 executor = SequentialExecutor
 sql_alchemy_conn = sqlite:///{AIRFLOW_HOME}/airflow.db
+parallelism = 32
 
 [webserver]
 base_url = http://localhost:8080

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -1,12 +1,25 @@
 import logging
 
 from airflow.utils import State
+from airflow.configuration import conf
+
+PARALLELISM = conf.get('core', 'PARALLELISM')
 
 
 class BaseExecutor(object):
 
-    def __init__(self):
-        self.commands = {}
+    def __init__(self, parallelism=PARALLELISM):
+        """
+        Class to derive in order to interface with executor-type systems
+        like Celery, Mesos, Yarn and the likes.
+
+        :param parallelism: how many jobs should run at one time. Set to
+            ``0`` for infinity
+        :type paralllelism: int
+        """
+        self.parallelism = parallelism
+        self.queue = {}
+        self.running = {}
         self.event_buffer = {}
 
     def start(self):  # pragma: no cover
@@ -16,17 +29,57 @@ class BaseExecutor(object):
         """
         pass
 
-    def queue_command(self, key, command):
-        """
-        """
-        if key not in self.commands or self.commands[key] != State.QUEUED:
+    def queue_command(self, key, command, priority=1):
+        if key not in self.queue and key not in self.running:
             logging.info("Adding to queue: " + command)
-            self.commands[key] = State.QUEUED
+            self.queue[key] = (command, priority)
+
+    def queue_task_instance(
+            self, task_instance, mark_success=False, pickle_id=None):
+        command = task_instance.command(
+            local=True,
+            mark_success=mark_success,
+            pickle_id=pickle_id)
+        self.queue_command(
+            task_instance.key,
+            command,
+            priority=task_instance.task.priority_weight_total)
+
+    def sync(self):
+        """
+        Sync will get called periodically by the heartbeat method.
+        Executors should override this to perform gather statuses.
+        """
+        pass
+
+    def heartbeat(self):
+        # Calling child class sync method
+        self.sync()
+
+        # Triggering new jobs
+        if not self.parallelism:
+            open_slots = len(self.queue)
+        else:
+            open_slots = self.parallelism - len(self.running)
+
+        sorted_queue = sorted(
+            [(k, v) for k, v in self.queue.items()],
+            key=lambda x: x[1][1],
+            reverse=True)
+        for i in range(min((open_slots, len(self.queue)))):
+            key, (command, priority) = sorted_queue.pop(0)
+            self.running[key] = command
             self.execute_async(key, command)
 
     def change_state(self, key, state):
-        self.commands[key] = state
+        del self.running[key]
         self.event_buffer[key] = state
+
+    def fail(self, key):
+        self.change_state(key, State.FAILED)
+
+    def success(self, key):
+        self.change_state(key, State.SUCCESS)
 
     def get_event_buffer(self):
         """

--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -3,9 +3,11 @@ import multiprocessing
 import subprocess
 import time
 
+from airflow.configuration import conf
+from airflow.executors.base_executor import BaseExecutor
 from airflow.utils import State
 
-from airflow.executors.base_executor import BaseExecutor
+PARALLELISM = conf.get('core', 'PARALLELISM')
 
 
 class LocalWorker(multiprocessing.Process):
@@ -37,19 +39,11 @@ class LocalWorker(multiprocessing.Process):
 
 
 class LocalExecutor(BaseExecutor):
-    '''
+    """
     LocalExecutor executes tasks locally in parallel. It uses the
     multiprocessing Python library and queues to parallelize the execution
     of tasks.
-    '''
-
-    def __init__(self, parallelism=16):
-        '''
-        :param parallelism: Number of processes running simultanously
-        :type parallelism: int
-        '''
-        super(LocalExecutor, self).__init__()
-        self.parallelism = parallelism
+    """
 
     def start(self):
         self.queue = multiprocessing.JoinableQueue()
@@ -65,7 +59,7 @@ class LocalExecutor(BaseExecutor):
     def execute_async(self, key, command):
         self.queue.put((key, command))
 
-    def heartbeat(self):
+    def sync(self):
         while not self.result_queue.empty():
             results = self.result_queue.get()
             self.change_state(*results)

--- a/airflow/executors/sequential_executor.py
+++ b/airflow/executors/sequential_executor.py
@@ -1,3 +1,4 @@
+import logging
 import subprocess
 
 from airflow.executors.base_executor import BaseExecutor
@@ -17,11 +18,12 @@ class SequentialExecutor(BaseExecutor):
         super(SequentialExecutor, self).__init__()
         self.commands_to_run = []
 
-    def queue_command(self, key, command):
+    def execute_async(self, key, command):
         self.commands_to_run.append((key, command,))
 
-    def heartbeat(self):
+    def sync(self):
         for key, command in self.commands_to_run:
+            logging.info("command" + str(command))
             try:
                 sp = subprocess.Popen(command, shell=True)
                 sp.wait()

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -275,8 +275,7 @@ class SchedulerJob(BaseJob):
                 if ti.is_runnable():
                     logging.info(
                         'First run for {ti}'.format(**locals()))
-                    cmd = ti.command(local=True)
-                    executor.queue_command(ti.key, cmd)
+                    executor.queue_task_instance(ti)
             else:
                 ti = ti_dict[task.task_id]
                 ti.task = task  # Hacky but worky
@@ -287,8 +286,7 @@ class SchedulerJob(BaseJob):
                     # the retry delay is met
                     if ti.is_runnable():
                         logging.debug('Queuing retry: ' + str(ti))
-                        cmd = ti.command(local=True)
-                        executor.queue_command(ti.key, cmd)
+                        executor.queue_task_instance(ti)
                 else:
                     # Trying to run the next schedule
                     next_schedule = (
@@ -304,8 +302,7 @@ class SchedulerJob(BaseJob):
                     ti.refresh_from_db()
                     if ti.is_runnable():
                         logging.debug('Queuing next run: ' + str(ti))
-                        cmd = ti.command(local=True)
-                        executor.queue_command(ti.key, cmd)
+                        executor.queue_task_instance(ti)
         # Releasing the lock
         db_dag = session.query(DagModel).filter(DagModel.dag_id==dag.dag_id).first()
         db_dag.scheduler_lock = False
@@ -449,12 +446,10 @@ class BackfillJob(BaseJob):
                     succeeded.append(key)
                     del tasks_to_run[key]
                 elif ti.is_runnable():
-                    executor.queue_command(
-                        key=ti.key, command=ti.command(
-                            mark_success=self.mark_success,
-                            local=True,
-                            pickle_id=pickle_id)
-                    )
+                    executor.queue_task_instance(
+                        ti,
+                        mark_success=self.mark_success,
+                        pickle_id=pickle_id)
                     ti.state = State.RUNNING
                     if key not in started:
                         started.append(key)

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -895,6 +895,10 @@ class BaseOperator(Base):
     :type wait_for_downstream: bool
     :param dag: a reference to the dag the task is attached to (if any)
     :type dag: DAG
+    :param priority_weight: priority weight of this task against other task.
+        This allows the executor to trigger higher priority tasks before
+        others when things get backed up.
+    :type priority_weight: int
     """
 
     # For derived classes to define which fields will get jinjaified
@@ -939,6 +943,7 @@ class BaseOperator(Base):
             params=None,
             default_args=None,
             adhoc=False,
+            priority_weight=1,
             *args,
             **kwargs):
 
@@ -962,6 +967,7 @@ class BaseOperator(Base):
             self.retry_delay = timedelta(seconds=retry_delay)
         self.params = params or {}  # Available in templates!
         self.adhoc = adhoc
+        self.priority_weight = priority_weight
         if dag:
             dag.add_task(self)
             self.dag = dag
@@ -981,6 +987,13 @@ class BaseOperator(Base):
             return self.dag.schedule_interval
         else:
             return self._schedule_interval
+
+    @property
+    def priority_weight_total(self):
+        return sum([
+            t.priority_weight
+            for t in  self.get_flat_relatives(upstream=False)
+        ]) + self.priority_weight
 
     def __cmp__(self, other):
         blacklist = {

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -2,3 +2,5 @@ export AIRFLOW_HOME=${AIRFLOW_HOME:=~/airflow}
 export AIRFLOW_CONFIG=$AIRFLOW_HOME/unittests.cfg
 rm airflow/www/static/coverage/*
 nosetests --with-doctest --with-coverage --cover-html --cover-package=airflow -v --cover-html-dir=airflow/www/static/coverage
+# To run idividual tests:
+# nosetests tests.core:CoreTest.test_scheduler_job


### PR DESCRIPTION
* Added a `priority_weight` default=1 to BaseOperator, some tasks (or dags) can be more important than others
* Added `priority_weight_total`, a BaseOperator property that returns the sum of the `priority_weight` of the downstream subgraph
* Added a setting to limit the parallelism of BaseExecutor, which means it now keeps a local buffer of queued up task when all the slots are taken
* When slots are freed, higher priority queued up tasks (based on the weight of the subtree) will go first
* Added a new configuration setting (core/parallelism) to set the parallelism of the executor

At the moment a DagBag has a single executor. I'm thinking of allowing each task to specify their executor, meaning that we could do some workload management and throttling in this way. 

For instance our production celery pool could have 256 slots, and we'd have a few executors to allocate these slots. Say 64 for backfill, 8 for ERF jobs (as they are expensive and have multiple MR phases), 32 for adhoc, and the balance for production jobs.