### PR TITLE
Fixing os file timestamp read race condition

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -131,7 +131,12 @@ class DagBag(object):
         Given a path to a python module, this method imports the module and
         look for dag objects whithin it.
         """
-        dttm = datetime.fromtimestamp(os.path.getmtime(filepath))
+        try:
+            # This failed before in what may have been a git sync
+            # race condition
+            dttm = datetime.fromtimestamp(os.path.getmtime(filepath))
+        except:
+            dttm = datetime(2001, 1, 1)
         mod_name, file_ext = os.path.splitext(os.path.split(filepath)[-1])
         mod_name = 'unusual_prefix_' + mod_name
 


### PR DESCRIPTION
A bug reading the os file timestamp failed a scheduler run on 2015-05-11, this should keep it from happening again.