### PR TITLE
Enabling queue management for Celery

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 '''
 Authentication is implemented using flask_login and different environments can

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -498,7 +498,7 @@ def get_parser():
     parser_worker.add_argument(
         "-q", "--queues",
         help="Coma delimeted list of queues to cater serve",
-        default=conf.get('celery', 'celery_default_queue'))
+        default=conf.get('celery', 'DEFAULT_QUEUE'))
     parser_worker.set_defaults(func=worker)
 
     ht = "Serve logs generate by worker"

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -286,7 +286,7 @@ def worker(args):
     options = {
         'optimization': 'fair',
         'O': 'fair',
-        'Q': args.queues,
+        'queues': args.queues,
     }
     worker.run(**options)
     sp.kill()

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -286,6 +286,7 @@ def worker(args):
     options = {
         'optimization': 'fair',
         'O': 'fair',
+        'Q': args.queues,
     }
     worker.run(**options)
     sp.kill()
@@ -494,6 +495,10 @@ def get_parser():
 
     ht = "Start a Celery worker node"
     parser_worker = subparsers.add_parser('worker', help=ht)
+    parser_worker.add_argument(
+        "-q", "--queues",
+        help="Coma delimeted list of queues to cater serve",
+        default=conf.get('celery', 'celery_default_queue'))
     parser_worker.set_defaults(func=worker)
 
     ht = "Serve logs generate by worker"

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -23,6 +23,9 @@ defaults = {
         'scheduler_heartbeat_sec': 60,
         'authenticate': False,
     },
+    'celery': {
+        'celery_default_queue': 'default',
+    },
 }
 
 DEFAULT_CONFIG = """\

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -24,7 +24,7 @@ defaults = {
         'authenticate': False,
     },
     'celery': {
-        'celery_default_queue': 'default',
+        'default_queue': 'default',
     },
 }
 
@@ -57,6 +57,7 @@ worker_log_server_port = 8793
 broker_url = sqla+mysql://airflow:airflow@localhost:3306/airflow
 celery_result_backend = db+mysql://airflow:airflow@localhost:3306/airflow
 flower_port = 8383
+default_queue = default
 
 [scheduler]
 job_heartbeat_sec = 5
@@ -92,6 +93,7 @@ worker_log_server_port = 8793
 broker_url = sqla+mysql://airflow:airflow@localhost:3306/airflow
 celery_result_backend = db+mysql://airflow:airflow@localhost:3306/airflow
 flower_port = 5555
+default_queue = default
 
 [scheduler]
 job_heartbeat_sec = 1

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -47,7 +47,7 @@ class BaseExecutor(object):
             task_instance.key,
             command,
             priority=task_instance.task.priority_weight_total,
-            queue=task_instance.queue)
+            queue=task_instance.task.queue)
 
     def sync(self):
         """

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -29,10 +29,10 @@ class BaseExecutor(object):
         """
         pass
 
-    def queue_command(self, key, command, priority=1):
+    def queue_command(self, key, command, priority=1, queue=None):
         if key not in self.queued_tasks and key not in self.running:
             logging.info("Adding to queue: " + command)
-            self.queued_tasks[key] = (command, priority)
+            self.queued_tasks[key] = (command, priority, queue)
 
     def queue_task_instance(
             self, task_instance, mark_success=False, pickle_id=None,
@@ -46,7 +46,8 @@ class BaseExecutor(object):
         self.queue_command(
             task_instance.key,
             command,
-            priority=task_instance.task.priority_weight_total)
+            priority=task_instance.task.priority_weight_total,
+            queue=task_instance.queue)
 
     def sync(self):
         """
@@ -75,10 +76,10 @@ class BaseExecutor(object):
             key=lambda x: x[1][1],
             reverse=True)
         for i in range(min((open_slots, len(self.queued_tasks)))):
-            key, (command, priority) = sorted_queue.pop(0)
+            key, (command, priority, queue) = sorted_queue.pop(0)
             self.running[key] = command
             del self.queued_tasks[key]
-            self.execute_async(key, command)
+            self.execute_async(key, command=command, queue=queue)
 
     def change_state(self, key, state):
         del self.running[key]
@@ -98,7 +99,7 @@ class BaseExecutor(object):
         self.event_buffer = {}
         return d
 
-    def execute_async(self, key, command):  # pragma: no cover
+    def execute_async(self, key, command, queue=None):  # pragma: no cover
         """
         This method will execute the command asynchronously.
         """

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -15,7 +15,7 @@ To start the celery worker, run the command:
 airflow worker
 '''
 
-CELERY_DEFAULT_QUEUE = conf.get('celery', 'CELERY_DEFAULT_QUEUE')
+DEFAULT_QUEUE = conf.get('celery', 'DEFAULT_QUEUE')
 
 
 class CeleryConfig(object):
@@ -25,7 +25,7 @@ class CeleryConfig(object):
     BROKER_URL = conf.get('celery', 'BROKER_URL')
     CELERY_RESULT_BACKEND = conf.get('celery', 'CELERY_RESULT_BACKEND')
     CELERYD_CONCURRENCY = conf.getint('celery', 'CELERYD_CONCURRENCY')
-    CELERY_DEFAULT_QUEUE = CELERY_DEFAULT_QUEUE
+    CELERY_DEFAULT_QUEUE = DEFAULT_QUEUE
 
 app = Celery(
     conf.get('celery', 'CELERY_APP_NAME'),
@@ -55,7 +55,7 @@ class CeleryExecutor(BaseExecutor):
         self.tasks = {}
         self.last_state = {}
 
-    def execute_async(self, key, command, queue=CELERY_DEFAULT_QUEUE):
+    def execute_async(self, key, command, queue=DEFAULT_QUEUE):
         self.tasks[key] = execute_command.apply_async(
             args=[command], queue=queue)
         self.last_state[key] = celery_states.PENDING

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -15,6 +15,8 @@ To start the celery worker, run the command:
 airflow worker
 '''
 
+CELERY_DEFAULT_QUEUE = conf.getint('celery', 'CELERY_DEFAULT_QUEUE')
+
 
 class CeleryConfig(object):
     CELERY_ACCEPT_CONTENT = ['json', 'pickle']
@@ -23,6 +25,7 @@ class CeleryConfig(object):
     BROKER_URL = conf.get('celery', 'BROKER_URL')
     CELERY_RESULT_BACKEND = conf.get('celery', 'CELERY_RESULT_BACKEND')
     CELERYD_CONCURRENCY = conf.getint('celery', 'CELERYD_CONCURRENCY')
+    CELERY_DEFAULT_QUEUE = CELERY_DEFAULT_QUEUE
 
 app = Celery(
     conf.get('celery', 'CELERY_APP_NAME'),
@@ -39,21 +42,21 @@ def execute_command(command):
 
 
 class CeleryExecutor(BaseExecutor):
-    '''
+    """
     CeleryExecutor is recommended for production use of Airflow. It allows
     distributing the execution of task instances to multiple worker nodes.
 
     Celery is a simple, flexible and reliable distributed system to process
     vast amounts of messages, while providing operations with the tools
     required to maintain such a system.
-    '''
+    """
 
     def start(self):
         self.tasks = {}
         self.last_state = {}
 
-    def execute_async(self, key, command):
-        self.tasks[key] = execute_command.delay(command)
+    def execute_async(self, key, command, queue=CELERY_DEFAULT_QUEUE):
+        self.tasks[key] = execute_command.delay(command, queue=queue)
         self.last_state[key] = celery_states.PENDING
 
     def sync(self):

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -56,7 +56,8 @@ class CeleryExecutor(BaseExecutor):
         self.last_state = {}
 
     def execute_async(self, key, command, queue=CELERY_DEFAULT_QUEUE):
-        self.tasks[key] = execute_command.delay(command, queue=queue)
+        self.tasks[key] = execute_command.apply_async(
+            args=[command], queue=queue)
         self.last_state[key] = celery_states.PENDING
 
     def sync(self):

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -15,7 +15,7 @@ To start the celery worker, run the command:
 airflow worker
 '''
 
-CELERY_DEFAULT_QUEUE = conf.getint('celery', 'CELERY_DEFAULT_QUEUE')
+CELERY_DEFAULT_QUEUE = conf.get('celery', 'CELERY_DEFAULT_QUEUE')
 
 
 class CeleryConfig(object):

--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -56,7 +56,7 @@ class LocalExecutor(BaseExecutor):
         for w in self.workers:
             w.start()
 
-    def execute_async(self, key, command):
+    def execute_async(self, key, command, queue=None):
         self.queue.put((key, command))
 
     def sync(self):

--- a/airflow/executors/sequential_executor.py
+++ b/airflow/executors/sequential_executor.py
@@ -18,7 +18,7 @@ class SequentialExecutor(BaseExecutor):
         super(SequentialExecutor, self).__init__()
         self.commands_to_run = []
 
-    def execute_async(self, key, command):
+    def execute_async(self, key, command, queue=None):
         self.commands_to_run.append((key, command,))
 
     def sync(self):

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -284,7 +284,13 @@ class SchedulerJob(BaseJob):
                     # If task instance if up for retry, make sure
                     # the retry delay is met
                     if ti.is_runnable():
-                        logging.debug('Queuing retry: ' + str(ti))
+                        logging.debug('Triggering retry: ' + str(ti))
+                        executor.queue_task_instance(ti)
+                elif ti.state == State.QUEUED:
+                    # If task instance if up for retry, make sure
+                    if ti.is_runnable():
+                        logging.debug(
+                            'Starting previously queued : ' + str(ti))
                         executor.queue_task_instance(ti)
                 else:
                     # Trying to run the next schedule

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -898,6 +898,10 @@ class BaseOperator(Base):
         This is useful if the different instances of a task X alter
         the same asset, and this asset is used by the dependencies of task X.
     :type wait_for_downstream: bool
+    :param queue: which queue to target when running this job. Not
+        all executors implement queue management, the CeleryExecutor
+        does support targeting specific queues.
+    :type queue: str
     :param dag: a reference to the dag the task is attached to (if any)
     :type dag: DAG
     :param priority_weight: priority weight of this task against other task.
@@ -949,6 +953,7 @@ class BaseOperator(Base):
             default_args=None,
             adhoc=False,
             priority_weight=1,
+            queue=None,
             *args,
             **kwargs):
 

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -970,6 +970,7 @@ class BaseOperator(Base):
         self.wait_for_downstream = wait_for_downstream
         self._schedule_interval = schedule_interval
         self.retries = retries
+        self.queue = queue
         if isinstance(retry_delay, timedelta):
             self.retry_delay = retry_delay
         else:

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -374,10 +374,14 @@ class TaskInstance(Base):
     hostname = Column(String(1000))
     unixname = Column(String(1000))
     job_id = Column(Integer)
+    pool = Column(String(50))
+    queue = Column(String(50))
+    priority_weight = Column(Integer)
 
     __table_args__ = (
         Index('ti_dag_state', dag_id, state),
         Index('ti_state_lkp', dag_id, task_id, execution_date, state),
+        Index('ti_pool', pool, state, priority_weight),
     )
 
     def __init__(self, task, execution_date, state=None, job=None):
@@ -386,6 +390,9 @@ class TaskInstance(Base):
         self.execution_date = execution_date
         self.state = state
         self.task = task
+        self.queue = task.queue
+        self.pool = task.pool
+        self.priority_weight = task.priority_weight_total
         self.try_number = 1
         self.unixname = getpass.getuser()
         if job:
@@ -616,6 +623,40 @@ class TaskInstance(Base):
         return self.state == State.UP_FOR_RETRY and \
             self.end_date + self.task.retry_delay < datetime.now()
 
+    def pool_full(self, session=None):
+        """
+        Returns a boolean as to whether the slot pool has room for this
+        task to run
+        """
+        if not self.task.pool:
+            return True
+
+        close_session = False
+        if not session:
+            session = settings.Session()
+            close_session = True
+
+        running = (
+            session
+            .query(func.count('*'))
+            .select_from(TaskInstance)
+            .scalar()
+        )
+        pool_size = (
+            session
+            .query(Pool)
+            .filter(Pool.pool == self.task.pool)
+            .first()
+        )
+        if not pool_size:
+            return False
+
+        if close_session:
+            session.commit()
+            session.close()
+        return running < pool_size
+
+
     def run(
             self,
             verbose=True,
@@ -661,6 +702,11 @@ class TaskInstance(Base):
                 "Next run after {0}".format(next_run)
             )
         elif force or self.state in State.runnable():
+            if not force and task.pool and self.pool_full(session):
+                self.state = State.QUEUED
+                session.commit()
+                logging.info("Pool {} is full, queuing".format(task.pool))
+                return
             if self.state == State.UP_FOR_RETRY:
                 self.try_number += 1
             else:
@@ -908,6 +954,9 @@ class BaseOperator(Base):
         This allows the executor to trigger higher priority tasks before
         others when things get backed up.
     :type priority_weight: int
+    :param pool: the slot pool this task should run in, slot pools are a
+        way to limit concurrency for certain tasks
+    :type pool: str
     """
 
     # For derived classes to define which fields will get jinjaified
@@ -954,6 +1003,7 @@ class BaseOperator(Base):
             adhoc=False,
             priority_weight=1,
             queue=None,
+            pool=None,
             *args,
             **kwargs):
 
@@ -1737,3 +1787,15 @@ class Variable(Base):
 
     def __repr__(self):
         return '{} : {}'.format(self.key, self.val)
+
+
+class Pool(Base):
+    __tablename__ = "slot_pool"
+
+    id = Column(Integer, primary_key=True)
+    pool = Column(String(50), unique=True)
+    slots = Column(Integer, default=0)
+    description = Column(Text)
+
+    def __repr__(self):
+        return self.id

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -49,7 +49,7 @@ class State(object):
 
     @classmethod
     def runnable(cls):
-        return [None, cls.FAILED, cls.UP_FOR_RETRY]
+        return [None, cls.FAILED, cls.UP_FOR_RETRY, cls.QUEUED]
 
 
 def pessimistic_connection_handling():

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -1447,7 +1447,8 @@ admin.add_view(mv)
 
 class TaskInstanceModelView(ModelViewOnly):
     column_filters = (
-        'dag_id', 'task_id', 'state', 'execution_date', 'hostname')
+        'dag_id', 'task_id', 'state', 'execution_date', 'hostname',
+        'queue', 'pool')
     named_filter_urls = True
     column_formatters = dict(
         log=log_link, task_id=task_instance_link,
@@ -1697,4 +1698,10 @@ class VariableView(LoginMixin, ModelView):
 
 mv = VariableView(
     models.Variable, Session, name="Variables", category="Admin")
+admin.add_view(mv)
+
+
+class PoolModelView(SuperUserMixin, ModelView):
+    pass
+mv = PoolModelView(models.Pool, Session, name="Pools", category="Admin")
 admin.add_view(mv)

--- a/migrations.sql
+++ b/migrations.sql
@@ -1,0 +1,5 @@
+// To 0.7
+alter table task_instance add column queue varchar(50) NULL;
+alter table task_instance add column pool varchar(50) NULL;
+alter table task_instance add column priority_weight INT NULL;
+create index ti_pool on task_instance (pool, state) using btree;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 boto
 celery
-celery[redis]
 chartkick
 coverage
 dill

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 # Kept manually in sync with airflow.__version__
-version = '0.6.0'
+version = '0.7.0'
 
 doc = [
     'sphinx>=1.2.3',


### PR DESCRIPTION
This PR adds Celery queue management to Airflow.

A default queue is assigned to workers and tasks. It is possible to specify a queue on a per-task basis. Workers can be started to serve specific queues.

For now only CeleryExecutor implement tasks, but future executors could implement as well.

This will come in handy for our upcoming cluster migration, could allow for insulation between dev and prod, managing skewed tasks (heavy CPU or memory hungry) on workers prepared for that purpose with the proper amount threads.