### PR TITLE
Artwr/erroring if relative is in different dag

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -147,7 +147,7 @@ def mkdir_p(path):
 
 '''
 Setting AIRFLOW_HOME and AIRFLOW_CONFIG from environment variables, using
-"~/airflow" and "~/airflow/airflow.cfg" repectively as defaults.
+"~/airflow" and "~/airflow/airflow.cfg" respectively as defaults.
 '''
 
 if 'AIRFLOW_HOME' not in os.environ:

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1246,8 +1246,8 @@ class BaseOperator(Base):
     def append_only_new(self, l, item):
         if any([item is t for t in l]):
             raise Exception(
-                'Dependency {self}, {item} already registered'
-                ''.format(**locals()))
+                "Dependency {self}, {item} already registered"
+                "".format(**locals()))
         else:
             l.append(item)
 
@@ -1256,7 +1256,10 @@ class BaseOperator(Base):
             task_or_task_list = [task_or_task_list]
         for task in task_or_task_list:
             if not isinstance(task_or_task_list, list):
-                raise Exception('Expecting a task')
+                raise Exception("Expecting a task")
+            if task.dag_id != self.dag_id:
+                raise Exception("The task referenced has a different DAG id.\n"
+                                "Please use an external task sensor")
             if upstream:
                 self.append_only_new(task._downstream_list, self)
                 self.append_only_new(self._upstream_list, task)

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1262,9 +1262,10 @@ class BaseOperator(Base):
             if not isinstance(task_or_task_list, list):
                 raise Exception('Expecting a task')
             if task.dag_id != self.dag_id:
-                if "adhoc" in self.dag_id or "adhoc" in task.dag_id:
-                    logging.debug("Setting dependencies for tasks"
-                                  " not attached to a DAG. Use dag.add_task.")
+                if (self.dag_id == "adhoc_" + self.owner
+                        or task.dag_id == "adhoc_" + task.owner):
+                    logging.debug("Setting dependencies for tasks not added to"
+                                  " a DAG. Don't forget to use dag.add_task.")
                 else:
                     raise Exception("Trying to set a task from another dag.\n"
                                     "Use an ExternalTaskSensor")

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -55,10 +55,10 @@ class State(object):
 def pessimistic_connection_handling():
     @event.listens_for(Pool, "checkout")
     def ping_connection(dbapi_connection, connection_record, connection_proxy):
-        '''
+        """
         Disconnect Handling - Pessimistic, taken from:
         http://docs.sqlalchemy.org/en/rel_0_9/core/pooling.html
-        '''
+        """
         cursor = dbapi_connection.cursor()
         try:
             cursor.execute("SELECT 1")

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -1,6 +1,11 @@
 export AIRFLOW_HOME=${AIRFLOW_HOME:=~/airflow}
 export AIRFLOW_CONFIG=$AIRFLOW_HOME/unittests.cfg
-rm airflow/www/static/coverage/*
+if [[ -d "airflow/www/static/coverage" ]]
+then
+  rm airflow/www/static/coverage/*
+else
+  mkdir -p "airflow/www/static/coverage"
+fi
 nosetests --with-doctest --with-coverage --cover-html --cover-package=airflow -v --cover-html-dir=airflow/www/static/coverage
-# To run idividual tests:
+# To run individual tests:
 # nosetests tests.core:CoreTest.test_scheduler_job


### PR DESCRIPTION
@mistercrunch.

Take 2. This does two things : 
  1) Make `task1._set_relative(task1)` act as a noop with just a debug logging. We can remove that if you would like. This would allow us to add a task to the dag and set it after to be downstream of all the roots of the dag.
The new pattern for for email could be :
```
    dag.add_task(email)
    email.set_upstream(dag.roots)
```
  2) Suppress does not throw an error if the non matching dag_id is equal to `"adhoc_" + owner`, which is what was happening for tasks setup without a `dag` parameter but within a dag definition file. This solves the errors we had with the pattern of setting an email operator at the end, but logs a debug message. The pattern above should not.

Let me know what you think.

(This has been tested on the dev webserver with all the dags in prod)