### PR TITLE
Removing problematic foreign key from Chart to Connection

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1728,8 +1728,7 @@ class Chart(Base):
 
     id = Column(Integer, primary_key=True)
     label = Column(String(200))
-    conn_id = Column(
-        String(ID_LEN), ForeignKey('connection.conn_id'), nullable=False)
+    conn_id = Column(String(ID_LEN), nullable=False)
     user_id = Column(Integer(), ForeignKey('user.id'),)
     chart_type = Column(String(100), default="line")
     sql_layout = Column(String(50), default="series")
@@ -1742,7 +1741,9 @@ class Chart(Base):
     owner = relationship(
         "User", cascade=False, cascade_backrefs=False, backref='charts')
     x_is_date = Column(Boolean, default=True)
-    db = relationship("Connection")
+    db = relationship(
+        "Connection",
+        primaryjoin='Chart.conn_id == foreign(Connection.conn_id)')
     iteration_no = Column(Integer, default=0)
     last_modified = Column(DateTime, default=datetime.now())
 


### PR DESCRIPTION
Since `conn_id` isn't unique anymore that was creating problem on DB init.
@krishnap 