### PR TITLE
Insure keeping the same connection through the sensor's lifecycle

### DIFF
--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -172,8 +172,9 @@ class HivePartitionSensor(BaseSensorOperator):
         logging.info(
             'Poking for table {self.schema}.{self.table}, '
             'partition {self.partition}'.format(**locals()))
-        self.hook = hooks.HiveMetastoreHook(
-            metastore_conn_id=self.metastore_conn_id)
+        if not hasattr(self, 'hook'):
+            self.hook = hooks.HiveMetastoreHook(
+                metastore_conn_id=self.metastore_conn_id)
         return self.hook.check_for_partition(
             self.schema, self.table, self.partition)
 


### PR DESCRIPTION
Say if we have 5 metastore connections, and one of them is faulty and sensors check every 3 minutes, all it takes is for one connection to go down for all of the sensors to end up failing over a few tries.

In this case, only the sensors hitting the faulty nodes would fail as soon as the connection goes bad, and if retries are set, there's 4 chances out of 5 that it will get retried on a healthy connection.

This will prevent outages like last night's.

@artwr @askeys 