### PR TITLE
Add schedule section to the tutorial

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -370,9 +370,9 @@ start_date specified itself, for which this dependency is disregarded.
     # start your backfill on a date range
     airflow backfill tutorial -s 2015-01-01 -e 2015-01-07
 
-Schedule
+Scheduler
 ''''''''
-``airflow schedule`` needs to be running for the tasks in your DAGs to be
+``airflow scheduler`` needs to be running for the tasks in your DAGs to be
 triggered at the appropriate future intervals by the scheduler. Use a daemon such as
 init scripts or supervisor to make sure the scheduler is running when your system starts.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -379,6 +379,8 @@ init scripts or supervisor to make sure the scheduler is running when your syste
 If you are using CeleryExecutor you will also need to ensure at least one instance of
 ``airflow worker`` is running to process the tasks in your queues.
 
+For more information please refer to the :doc:`scheduler` section.
+
 
 What's Next?
 -------------

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -370,6 +370,15 @@ start_date specified itself, for which this dependency is disregarded.
     # start your backfill on a date range
     airflow backfill tutorial -s 2015-01-01 -e 2015-01-07
 
+Schedule
+''''''''
+``airflow schedule`` needs to be running for the tasks in your DAGs to be
+triggered at the appropriate future intervals by the scheduler. Use a daemon such as
+init scripts or supervisor to make sure the scheduler is running when your system starts.
+
+If you are using CeleryExecutor you will also need to ensure at least one instance of
+``airflow worker`` is running to process the tasks in your queues.
+
 
 What's Next?
 -------------


### PR DESCRIPTION
Hi, when trying to understand scheduling I referred to the tutorial. I think a docs section on putting airflow into production would be great. But, for now a quick mention of 'airflow schedule' seems appropriate in the tutorial.